### PR TITLE
Add a trigger to allow manual run of the Github Action

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Mondoo Build Version'
+        required: true
+        type: string
+
 
 jobs:
   build_container:


### PR DESCRIPTION
Based on the Github ["Manually run a workflow" ](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) documentation.


Signed-off-by: Ben Rockwood <benr@cuddletech.com>